### PR TITLE
fix: activate window and tab when focusing iTerm2 pane

### DIFF
--- a/docs/superpowers/specs/2026-03-18-iterm2-minimized-windows-design.md
+++ b/docs/superpowers/specs/2026-03-18-iterm2-minimized-windows-design.md
@@ -1,0 +1,38 @@
+# iTerm2: Focus Minimized/Background Windows
+
+**Date:** 2026-03-18
+**Issue:** #14
+**Status:** Draft
+
+## Problem
+
+When an iTerm2 window is minimized, pressing Enter in cctop to focus a session shows "No iTerm2 pane found for this session" instead of un-minimizing the window and focusing the correct pane. Non-active tabs in visible windows work fine.
+
+## Root Cause
+
+`ITermBridge.activate_session()` calls `session.async_activate()` which activates the pane and switches tabs within a visible window, but does not un-minimize the containing window. The current code builds a `pid_map: dict[int, session]` that maps PIDs to iTerm2 session objects only — it discards the window and tab references.
+
+## Design
+
+### Change to `activate_session()` in `src/cctop/sources/iterm2.py`
+
+1. **Track window and tab alongside session in the PID map.** Change from `pid_map: dict[int, session]` to `pid_map: dict[int, tuple[window, tab, session]]`.
+
+2. **On PID match, activate in order:**
+   - `await window.async_activate()` — un-minimizes the window and brings it to the foreground
+   - `await tab.async_select()` — switches to the correct tab
+   - `await session.async_activate()` — focuses the specific pane
+
+3. **No behavior change for non-minimized windows.** Calling `window.async_activate()` on an already-visible window is a no-op (it just ensures focus). Same for `tab.async_select()` on the active tab.
+
+### Testing
+
+- **Unit tests:** Mock iTerm2 objects and verify all three activation calls (`window.async_activate()`, `tab.async_select()`, `session.async_activate()`) are made in order when a PID match is found.
+- **Unit test:** Verify that when no match is found, no activation calls are made and `False` is returned.
+- **Manual verification:** Minimize an iTerm2 window running a Claude session, press Enter in cctop, confirm the window un-minimizes and the correct pane is focused.
+
+### Scope
+
+- Only `src/cctop/sources/iterm2.py` is modified (the `activate_session` method)
+- No changes to `session_list.py` or the notification logic
+- No new dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-cctop"
-version = "0.2.1"
+version = "0.2.2"
 description = "A htop-like TUI for monitoring Claude Code sessions in real-time"
 readme = "README.md"
 license = "MIT"

--- a/src/cctop/sources/iterm2.py
+++ b/src/cctop/sources/iterm2.py
@@ -66,7 +66,7 @@ class ITermBridge:
             pid_map: dict[int, tuple[object, object, object]] = {}
             for window in app.windows:
                 for tab in window.tabs:
-                    for session in tab.sessions:
+                    for session in tab.all_sessions:
                         root_pid = await session.async_get_variable("pid")
                         pid_map[root_pid] = (window, tab, session)
 

--- a/src/cctop/sources/iterm2.py
+++ b/src/cctop/sources/iterm2.py
@@ -62,19 +62,23 @@ class ITermBridge:
         try:
             app = await getattr(_iterm2, "async_get_app")(self._connection)
 
-            # Build root-PID -> iTerm2 session map
-            pid_map: dict[int, object] = {}
+            # Build root-PID -> (window, tab, session) map
+            pid_map: dict[int, tuple[object, object, object]] = {}
             for window in app.windows:
                 for tab in window.tabs:
                     for session in tab.sessions:
                         root_pid = await session.async_get_variable("pid")
-                        pid_map[root_pid] = session
+                        pid_map[root_pid] = (window, tab, session)
 
             # Walk up from Claude PID to find a match
             p = getattr(_psutil, "Process")(claude_pid)
             while p.pid > 1:
                 if p.pid in pid_map:
-                    await getattr(pid_map[p.pid], "async_activate")()
+                    window, tab, session = pid_map[p.pid]
+                    # Activate window first (un-minimizes if needed), then tab, then pane
+                    await getattr(window, "async_activate")()
+                    await getattr(tab, "async_select")()
+                    await getattr(session, "async_activate")()
                     logger.debug("Focused iTerm2 session for PID {}", claude_pid)
                     return True
                 parent = p.parent()

--- a/tests/test_sources_iterm2.py
+++ b/tests/test_sources_iterm2.py
@@ -50,7 +50,7 @@ async def test_connect_api_server_disabled() -> None:
 
 @pytest.mark.asyncio
 async def test_activate_session_success() -> None:
-    """PID walk-up finds matching iTerm2 session and activates it."""
+    """PID walk-up finds matching iTerm2 session and activates window, tab, and pane."""
     mock_iterm_session = AsyncMock()
     mock_iterm_session.session_id = "iterm-session-1"
 
@@ -69,9 +69,9 @@ async def test_activate_session_success() -> None:
 
     # Mock iTerm2 app with one session whose root PID is 10
     mock_app = AsyncMock()
-    mock_tab = MagicMock()
+    mock_tab = AsyncMock()
     mock_tab.sessions = [mock_iterm_session]
-    mock_window = MagicMock()
+    mock_window = AsyncMock()
     mock_window.tabs = [mock_tab]
     mock_app.windows = [mock_window]
     mock_iterm_session.async_get_variable = AsyncMock(return_value=10)
@@ -92,7 +92,64 @@ async def test_activate_session_success() -> None:
         result = await bridge.activate_session(100)
 
     assert result is True
+    mock_window.async_activate.assert_awaited_once()
+    mock_tab.async_select.assert_awaited_once()
     mock_iterm_session.async_activate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_activate_session_activates_window_tab_and_pane_in_order() -> None:
+    """Activation calls happen in order: window, tab, session."""
+    call_order: list[str] = []
+
+    mock_iterm_session = AsyncMock()
+
+    async def record_session_activate() -> None:
+        call_order.append("session")
+
+    mock_iterm_session.async_activate = AsyncMock(side_effect=record_session_activate)
+    mock_iterm_session.async_get_variable = AsyncMock(return_value=50)
+
+    mock_tab = AsyncMock()
+
+    async def record_tab_select() -> None:
+        call_order.append("tab")
+
+    mock_tab.async_select = AsyncMock(side_effect=record_tab_select)
+    mock_tab.sessions = [mock_iterm_session]
+
+    mock_window = AsyncMock()
+
+    async def record_window_activate() -> None:
+        call_order.append("window")
+
+    mock_window.async_activate = AsyncMock(side_effect=record_window_activate)
+    mock_window.tabs = [mock_tab]
+
+    mock_app = AsyncMock()
+    mock_app.windows = [mock_window]
+
+    # Direct match: claude PID == root PID
+    mock_process = MagicMock()
+    mock_process.pid = 50
+
+    bridge = ITermBridge()
+    bridge._available = True
+    bridge._connection = MagicMock()
+
+    mock_iterm2_mod = MagicMock()
+    mock_iterm2_mod.async_get_app = AsyncMock(return_value=mock_app)
+    mock_psutil_mod = MagicMock()
+    mock_psutil_mod.Process.return_value = mock_process
+
+    with (
+        patch("cctop.sources.iterm2._iterm2", mock_iterm2_mod),
+        patch("cctop.sources.iterm2._psutil", mock_psutil_mod),
+    ):
+        result = await bridge.activate_session(50)
+
+    assert result is True
+    assert call_order == ["window", "tab", "session"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sources_iterm2.py
+++ b/tests/test_sources_iterm2.py
@@ -70,7 +70,7 @@ async def test_activate_session_success() -> None:
     # Mock iTerm2 app with one session whose root PID is 10
     mock_app = AsyncMock()
     mock_tab = AsyncMock()
-    mock_tab.sessions = [mock_iterm_session]
+    mock_tab.all_sessions = [mock_iterm_session]
     mock_window = AsyncMock()
     mock_window.tabs = [mock_tab]
     mock_app.windows = [mock_window]
@@ -116,7 +116,7 @@ async def test_activate_session_activates_window_tab_and_pane_in_order() -> None
         call_order.append("tab")
 
     mock_tab.async_select = AsyncMock(side_effect=record_tab_select)
-    mock_tab.sessions = [mock_iterm_session]
+    mock_tab.all_sessions = [mock_iterm_session]
 
     mock_window = AsyncMock()
 
@@ -150,6 +150,59 @@ async def test_activate_session_activates_window_tab_and_pane_in_order() -> None
 
     assert result is True
     assert call_order == ["window", "tab", "session"]
+
+
+@pytest.mark.asyncio
+async def test_activate_session_finds_minimized_pane() -> None:
+    """PID walk-up finds a session that is minimized within its tab (maximized pane)."""
+    mock_visible_session = AsyncMock()
+    mock_visible_session.async_get_variable = AsyncMock(return_value=10)
+
+    mock_minimized_session = AsyncMock()
+    mock_minimized_session.async_get_variable = AsyncMock(return_value=20)
+
+    # all_sessions includes both visible and minimized; the Claude process is under the minimized one
+    mock_tab = AsyncMock()
+    mock_tab.all_sessions = [mock_visible_session, mock_minimized_session]
+    mock_window = AsyncMock()
+    mock_window.tabs = [mock_tab]
+
+    mock_app = AsyncMock()
+    mock_app.windows = [mock_window]
+
+    # claude(200) -> fish(30) -> login(20) — login PID matches minimized session root PID
+    mock_login = MagicMock()
+    mock_login.pid = 20
+    mock_login.parent.return_value = None
+
+    mock_fish = MagicMock()
+    mock_fish.pid = 30
+    mock_fish.parent.return_value = mock_login
+
+    mock_claude = MagicMock()
+    mock_claude.pid = 200
+    mock_claude.parent.return_value = mock_fish
+
+    bridge = ITermBridge()
+    bridge._available = True
+    bridge._connection = MagicMock()
+
+    mock_iterm2_mod = MagicMock()
+    mock_iterm2_mod.async_get_app = AsyncMock(return_value=mock_app)
+    mock_psutil_mod = MagicMock()
+    mock_psutil_mod.Process.return_value = mock_claude
+
+    with (
+        patch("cctop.sources.iterm2._iterm2", mock_iterm2_mod),
+        patch("cctop.sources.iterm2._psutil", mock_psutil_mod),
+    ):
+        result = await bridge.activate_session(200)
+
+    assert result is True
+    mock_window.async_activate.assert_awaited_once()
+    mock_tab.async_select.assert_awaited_once()
+    mock_minimized_session.async_activate.assert_awaited_once()
+    mock_visible_session.async_activate.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "claude-cctop"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Summary

- Fixes #14: pressing Enter in cctop now un-minimizes the iTerm2 window and switches to the correct tab before focusing the pane
- The `pid_map` now stores `(window, tab, session)` tuples instead of just session objects
- On match, calls `window.async_activate()` → `tab.async_select()` → `session.async_activate()` in order
- Bumps version to 0.2.2

## Test plan

- [ ] Existing tests updated to verify `window.async_activate()` and `tab.async_select()` are called
- [ ] New test verifies activation order: window → tab → session
- [ ] Manual test: minimize an iTerm2 window with a Claude session, press Enter in cctop, confirm the window un-minimizes and the correct pane is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)